### PR TITLE
Add deps badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Exparse [![Inline docs](http://inch-ci.org/github/NobbZ/exparse.svg)](http://inch-ci.org/github/NobbZ/exparse)
+# Exparse [![Inline docs](http://inch-ci.org/github/NobbZ/exparse.svg)](http://inch-ci.org/github/NobbZ/exparse) [![Deps Status](https://beta.hexfaktor.org/badge/all/github/NobbZ/exparse.svg)](https://beta.hexfaktor.org/github/NobbZ/exparse)
 
 **TODO: Add description**
 


### PR DESCRIPTION
Hi Nobbz,

you registrered on hexfaktor.org a while back to be included in the beta of HexFaktor. Here we go:

[![Deps Status](https://beta.hexfaktor.org/badge/all/github/NobbZ/exparse.svg)](https://beta.hexfaktor.org/github/NobbZ/exparse) [![Inline docs](http://inch-ci.org/github/NobbZ/exparse.svg)](http://inch-ci.org/github/NobbZ/exparse)

You already know the Inch badge on the right: It shows you an analysis for your Elixir project's docs. The new badge does the same thing for your dependencies.

Behind the badge works a CI service written in Elixir which can notify you whenever important updates for your Hex packages are released.

This is still in its infancy, and I want to basically invite you to join the beta to test-drive this. I really believe that we can create a great service for the community with this. That said, don't feel any obligation to accept the PR. You can't hurt my feelings by voicing your honest opinion about this idea! :wink:
